### PR TITLE
Support mapping to different database names

### DIFF
--- a/ctrl_z/__init__.py
+++ b/ctrl_z/__init__.py
@@ -1,7 +1,7 @@
 from pkg_resources import get_distribution
 
+from ._cli import cli  # noqa
 from .backup import Backup, configure_logging  # noqa
-from .cli import cli  # noqa
 
 __version__ = get_distribution('CTRL-Z').version
 

--- a/ctrl_z/_cli.py
+++ b/ctrl_z/_cli.py
@@ -36,7 +36,7 @@ class readable_dir(argparse.Action):
 
 class db_alias(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
-        _values = []
+        _values = getattr(namespace, self.dest) or []
 
         # check correct format
         for value in values:

--- a/ctrl_z/backup.py
+++ b/ctrl_z/backup.py
@@ -202,6 +202,13 @@ class Backup:
         filename = self._get_db_filename(db_config)
         backup_file = os.path.join(self.db_dir, filename)
 
+        if not os.path.isfile(backup_file):
+            raise BackupError(
+                "Dump file '{backup_file}' does not exist. Possibly you need "
+                "to provide the alias mapping if you're restoring to a "
+                "different database name.".format(backup_file=backup_file)
+            )
+
         args = [
             program,
             "-dpostgres",

--- a/ctrl_z/backup.py
+++ b/ctrl_z/backup.py
@@ -113,7 +113,7 @@ class Backup:
             self._backup_database(db_config)
 
     def restore_databases(self, skip_db=None):
-        logger.info("Restoring%d databases", len(settings.DATABASES))
+        logger.info("Restoring %d databases", len(settings.DATABASES))
         for alias, db_config in settings.DATABASES.items():
             if skip_db and alias in skip_db:
                 continue

--- a/ctrl_z/backup.py
+++ b/ctrl_z/backup.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import subprocess
 from datetime import datetime
+from typing import Optional
 
 from django.conf import settings
 from django.core.mail import send_mail
@@ -36,13 +37,13 @@ class Backup:
         config = Config.from_file(config_file, base_dir=base_dir, restore=True)
         return cls(config=config)
 
-    def restore(self, db=True, skip_db=None, files=True):
+    def restore(self, db=True, skip_db=None, files=True, db_names: Optional[dict] = None):
         logger.info("Starting restore of %s", self.base_dir)
 
         if files:
             self.restore_files()
         if db:
-            self.restore_databases(skip_db=skip_db)
+            self.restore_databases(skip_db=skip_db, db_names=db_names)
 
         logger.info("Finished restore of %s", self.base_dir)
 
@@ -112,12 +113,13 @@ class Backup:
                 continue
             self._backup_database(db_config)
 
-    def restore_databases(self, skip_db=None):
+    def restore_databases(self, skip_db=None, db_names: Optional[dict] = None):
         logger.info("Restoring %d databases", len(settings.DATABASES))
         for alias, db_config in settings.DATABASES.items():
             if skip_db and alias in skip_db:
                 continue
-            self._restore_database(alias, db_config)
+            source_db_name = db_names.get(alias) if db_names else None
+            self._restore_database(alias, db_config, source_db_name=source_db_name)
 
     def files(self):
         """
@@ -195,11 +197,15 @@ class Backup:
 
         logger.info("Database backup saved to %s", outfile)
 
-    def _restore_database(self, alias: str, db_config: dict):
+    def _restore_database(self, alias: str, db_config: dict, source_db_name: Optional[str] = None):
         program = self.config.pg_restore_binary
 
+        source_db_config = db_config.copy()
+        if source_db_name:
+            source_db_config['NAME'] = source_db_name
+
         host, port, name = self._get_conn_params(db_config)
-        filename = self._get_db_filename(db_config)
+        filename = self._get_db_filename(source_db_config)
         backup_file = os.path.join(self.db_dir, filename)
 
         if not os.path.isfile(backup_file):

--- a/ctrl_z/cli.py
+++ b/ctrl_z/cli.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 import django
+from django.conf import settings
 
 from .backup import Backup, configure_logging
 from .config import DEFAULT_CONFIG_FILE
@@ -31,6 +32,31 @@ class readable_dir(argparse.Action):
             raise argparse.ArgumentTypeError(
                 "{0} is not a readable dir".format(prospective_dir)
             )
+
+
+class db_alias(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        _values = []
+
+        # check correct format
+        for value in values:
+            if ':' not in value:
+                raise argparse.ArgumentTypeError(
+                    "{0} has an invalid format - it should be 'alias:name'".format(value)
+                )
+
+        # check that aliases exist
+        for value in values:
+            alias, db_name = value.split(':', 1)
+            if alias not in settings.DATABASES:
+                raise argparse.ArgumentTypeError(
+                    "Alias '{alias}' is not configured in the django settings".format(
+                        alias=alias
+                    )
+                )
+            _values.append((alias, db_name))
+
+        setattr(namespace, self.dest, _values)
 
 
 class CLI:
@@ -103,6 +129,15 @@ class CLI:
             help="Directory containing the backups"
         )
         parser_restore.add_argument(
+            '--db-name', dest='db_names',
+            metavar='ALIAS:DB_NAME', nargs="+", action=db_alias,
+            help="Mapping of database alias to database name. Useful if you're "
+                 "restoring from one environment to another one. Format is "
+                 "alias:name, where the alias is the alias used in the "
+                 "settings of the target, and the name is the database name "
+                 "of the source database."
+        )
+        parser_restore.add_argument(
             '--no-db', '--no-database', dest='restore_db',
             action='store_false', default=True,
             help="Do not restore the databases"
@@ -134,10 +169,10 @@ class CLI:
         version_string = "CTRL-Z {version} - Backup and recovery tool\n".format(version=__version__)
         self.stderr.write(version_string)
 
+        self._setup()
+
         args = self.parser.parse_args(args or sys.argv[1:])
         config_file = args.config_file or config_file
-
-        self._setup()
 
         self.run(args, config_file)
 
@@ -211,13 +246,17 @@ class CLI:
         restore_db = options.restore_db
         skip_db = options.skip_db
         restore_files = options.restore_files
+        db_names = dict(options.db_names or ())
 
         backup = self._backup
 
         # perform the restore
         has_errors = False
         try:
-            backup.restore(db=restore_db, skip_db=skip_db, files=restore_files)
+            backup.restore(
+                db=restore_db, skip_db=skip_db,
+                files=restore_files, db_names=db_names
+            )
         except Exception:
             has_errors = True
             logger.exception("Restore failed")

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -136,3 +136,8 @@ Restore the backup at the specified path.
   for. Useful if you have a multi-db setup and only the ``default`` is important,
   for example. Use multiple times for each alias to skip.
 * ``--no-files``: do not restore the (uploaded) files (e.g. ``settings.MEDIA_ROOT``)
+* ``--db-name``: convenient for loading a different source database name into
+  the target environment. Syntax: ``alias:name``, for example
+  ``default:project_staging``. Dump files are saved with the database name in
+  the file name, so this allows you to refer to that. Can be used multiple
+  times for multi-db setups.

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ tests =
     pytest
     pytest-django
     pytest-freezegun
+    pytest-mock
     tox
     isort
 pep8 = flake8

--- a/tests/backups/2018-06-27-daily/db/localhost.5432.dummy.custom
+++ b/tests/backups/2018-06-27-daily/db/localhost.5432.dummy.custom
@@ -1,0 +1,1 @@
+localhost.PORT.ctrlz.custom

--- a/tests/backups/2018-06-27-daily/db/localhost.5433.dummy.custom
+++ b/tests/backups/2018-06-27-daily/db/localhost.5433.dummy.custom
@@ -1,0 +1,1 @@
+localhost.PORT.ctrlz.custom

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -107,3 +107,94 @@ def test_full_restore_not_directory(tmpdir):
 
     with pytest.raises(argparse.ArgumentTypeError):
         cli(args=['restore', str(some_file)], stdout=StringIO())
+
+
+def test_db_restore_bad_alias_syntax(tmpdir, settings, config_writer):
+    config_path = str(tmpdir.join('config.yml'))
+    backups_base = tmpdir.mkdir('backups')
+    backup_dir = backups_base.mkdir('2018-05-29-daily')
+    backup_dir.mkdir('db')
+    backup_dir.mkdir('files')
+
+    config_writer(config_path, base_dir=str(backups_base))
+
+    # prevent actual db access
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=UserWarning)
+        settings.DATABASES = {}
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli(
+            args=['restore', str(backup_dir), '--db-name', 'foo.bar'],
+            config_file=config_path, stdout=StringIO(),
+        )
+
+
+def test_db_restore_alias_not_present(tmpdir, settings, config_writer):
+    config_path = str(tmpdir.join('config.yml'))
+    backups_base = tmpdir.mkdir('backups')
+    backup_dir = backups_base.mkdir('2018-05-29-daily')
+    backup_dir.mkdir('db')
+    backup_dir.mkdir('files')
+
+    config_writer(config_path, base_dir=str(backups_base))
+
+    # prevent actual db access
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=UserWarning)
+        settings.DATABASES = {}
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli(
+            args=['restore', str(backup_dir), '--db-name', 'default:dummy'],
+            config_file=config_path, stdout=StringIO(),
+        )
+
+
+def test_db_restore_dbname_alias(tmpdir, config_writer, mocker):
+    config_path = str(tmpdir.join('config.yml'))
+    backups_base = tmpdir.mkdir('backups')
+    backup_dir = backups_base.mkdir('2018-05-29-daily')
+    backup_dir.mkdir('db')
+    backup_dir.mkdir('files')
+
+    config_writer(config_path, base_dir=str(backups_base))
+
+    mock_restore = mocker.patch('ctrl_z._cli.Backup.restore')
+
+    cli(
+        args=[
+            'restore', str(backup_dir),
+            '--db-name', 'default:dummy',
+            '--db-name', 'secondary:dummy2',
+        ],
+        config_file=config_path, stdout=StringIO(),
+    )
+
+    mock_restore.assert_called_once_with(
+        db=True,
+        db_names={
+            'default': 'dummy',
+            'secondary': 'dummy2',
+        },
+        files=True,
+        skip_db=None
+    )
+
+
+@pytest.mark.freeze_time('2018-05-29')
+def test_show_backup_dir(tmpdir, config_writer):
+    config_path = str(tmpdir.join('config.yml'))
+    backups_base = tmpdir.mkdir('backups')
+
+    config_writer(config_path, base_dir=str(backups_base))
+
+    stdout = StringIO()
+
+    cli(args=['show_backup_dir'], config_file=config_path, stdout=stdout)
+
+    stdout.seek(0)
+    output = stdout.read()
+
+    expected_dir = backups_base.join('2018-05-29-daily')
+    assert output == "{path}\n".format(path=str(expected_dir))


### PR DESCRIPTION
This simplifies flows where database names don't line up, for example from staging -> dev environment or production -> staging