### PR TITLE
Make sure connections are dropped before dropping database

### DIFF
--- a/ctrl_z/backup.py
+++ b/ctrl_z/backup.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 
 from django.conf import settings
 from django.core.mail import send_mail
+from django.db import connections
 from django.utils.module_loading import import_string
 
 from .config import Config
@@ -252,7 +253,7 @@ class Backup:
                 "different database name.".format(backup_file=backup_file)
             )
 
-        dropdb_args = [self.config.dropdb_binary, "--if-exists", db_config["NAME"], "--maintenance-db=template1"]
+        dropdb_args = [self.config.dropdb_binary, "--if-exists", db_config["NAME"]]
 
         createdb_args = [self.config.createdb_binary, db_config["NAME"]]
 
@@ -272,6 +273,10 @@ class Backup:
         )
 
         logger.info("Dropping the target database, if it exists")
+        
+        for conn in connections.all():
+            conn.close()
+        
         process = subprocess.Popen(
             dropdb_args, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )

--- a/ctrl_z/backup.py
+++ b/ctrl_z/backup.py
@@ -252,7 +252,7 @@ class Backup:
                 "different database name.".format(backup_file=backup_file)
             )
 
-        dropdb_args = [self.config.dropdb_binary, "--if-exists", db_config["NAME"], "--maintenance-db=template0"]
+        dropdb_args = [self.config.dropdb_binary, "--if-exists", db_config["NAME"], "--maintenance-db=template1"]
 
         createdb_args = [self.config.createdb_binary, db_config["NAME"]]
 

--- a/ctrl_z/backup.py
+++ b/ctrl_z/backup.py
@@ -252,7 +252,7 @@ class Backup:
                 "different database name.".format(backup_file=backup_file)
             )
 
-        dropdb_args = [self.config.dropdb_binary, "--if-exists", db_config["NAME"]]
+        dropdb_args = [self.config.dropdb_binary, "--if-exists", db_config["NAME"], "--maintenance-db=template0"]
 
         createdb_args = [self.config.createdb_binary, db_config["NAME"]]
 


### PR DESCRIPTION
This PR makes sure all open database connections are dropped before attempting to run dropdb. This will make sure dropdb will not run into issues dropping the database with the following error:

2021-04-28 11:51:25 - INFO - Dropping the target database, if it exists
2021-04-28 11:51:30 - INFO - stderr: dropdb: database removal failed: ERROR:  database "postgres" is being accessed by other users
DETAIL:  There is 1 other session using the database.