### PR TITLE
Feature/nextpl 470 set owner to restore user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
+  - "3.9"
 
 services:
   - postgresql
@@ -24,14 +26,15 @@ env:
     - DJANGO=2.0
     - DJANGO=2.1
     - DJANGO=2.2
+    - DJANGO=3.2
 
 matrix:
   fast_finish: true
   include:
-    - python: "3.6"
+    - python: "3.9"
       env: TOXENV=isort
 
-    - python: "3.6"
+    - python: "3.9"
       env: TOXENV=docs
 
 install:

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ CTRL-Z (control-zee) is a backup and recovery tool for Django projects.
 Its goals are to be operating system agnostic in creating and restoring backups,
 while being flexible through a yaml configuration file.
 
-|build-status| |requirements| |coverage| |docs|
+|build-status| |coverage| |docs|
 
 |python-versions| |django-versions| |pypi-version|
 
@@ -39,10 +39,6 @@ See the `documentation`_.
 .. |build-status| image:: https://travis-ci.org/isprojects/ctrl-z.svg?branch=develop
     :target: https://travis-ci.org/isprojects/ctrl-z
     :alt: Build status
-
-.. |requirements| image:: https://requires.io/github/isprojects/ctrl-z/requirements.svg?branch=develop
-    :target: https://requires.io/github/isprojects/ctrl-z/requirements/?branch=develop
-    :alt: Requirements status
 
 .. |coverage| image:: https://codecov.io/gh/isprojects/ctrl-z/branch/develop/graph/badge.svg
     :target: https://codecov.io/gh/isprojects/ctrl-z

--- a/ctrl_z/backup.py
+++ b/ctrl_z/backup.py
@@ -257,7 +257,7 @@ class Backup:
 
         createdb_args = [self.config.createdb_binary, db_config["NAME"]]
 
-        args = [program, "-d%s" % db_config["NAME"], backup_file]
+        args = [program, "-d%s" % db_config["NAME"], "-O", backup_file]
 
         logger.info("Restoring database %s (%s:%s)", name, host, port)
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,7 +6,7 @@
 Welcome to CTRL-Z's documentation!
 ===========================================
 
-|build-status| |requirements| |coverage|
+|build-status| |coverage|
 
 |python-versions| |django-versions| |pypi-version|
 
@@ -33,10 +33,6 @@ Indices and tables
 
 .. |build-status| image:: https://travis-ci.org/isprojects/ctrl-z.svg?branch=develop
     :target: https://travis-ci.org/isprojects/ctrl-z
-
-.. |requirements| image:: https://requires.io/github/isprojects/ctrl-z/requirements.svg?branch=develop
-    :target: https://requires.io/github/isprojects/ctrl-z/requirements/?branch=develop
-    :alt: Requirements status
 
 .. |coverage| image:: https://codecov.io/gh/isprojects/ctrl-z/branch/develop/graph/badge.svg
     :target: https://codecov.io/gh/isprojects/ctrl-z

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ long_description = file: README.rst
 url = https://github.com/isprojects/ctrl-z
 license = MIT
 author = ISProjects B.V, Sergei Maertens
-author_email = support@isprojects.nl
+author_email = support@ispnext.com
 keywords = django, backup, recovery
 classifiers =
     Development Status :: 5 - Production/Stable
@@ -17,6 +17,7 @@ classifiers =
     Framework :: Django :: 2.0
     Framework :: Django :: 2.1
     Framework :: Django :: 2.2
+    Framework :: Django :: 3.2
     Intended Audience :: Developers
     Operating System :: Unix
     Operating System :: MacOS
@@ -24,6 +25,8 @@ classifiers =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{35,36,37}-django{111,20,21,22}
+  py{35,36,37,38,39}-django{111,20,21,22,32}
   isort
   docs
 skip_missing_interpreters = true
@@ -11,7 +11,7 @@ DJANGO =
     2.0: django20
     2.1: django21
     2.2: django22
-
+    3.2: django32
 [testenv]
 extras =
     tests
@@ -21,6 +21,7 @@ deps =
   django20: Django>=2.0,<2.1
   django21: Django>=2.1,<2.2
   django22: Django>=2.2,<3.0
+  django32: Django>=3.2,<3.3
 passenv =
   PGUSER
   PGPORT


### PR DESCRIPTION
This PR fixes the version numbers in the docs and tests we missed last PR and adds the -O flag to the restore to automatically set the owner of everything restored to the user executing the restore. 

This will remove the GRANT errors when restoring a database to another user.