### PR TITLE
NEXTPL-1217 Import fault handling in ctrl-z

### DIFF
--- a/ctrl_z/backup.py
+++ b/ctrl_z/backup.py
@@ -162,6 +162,9 @@ class Backup:
             self._restore_directory(path)
 
     def _get_file_directories(self) -> list:
+        if not (self.config.files.get("directories")):
+            return []
+
         directories = [
             getattr(settings, setting) for setting in self.config.files["directories"]
         ]
@@ -320,6 +323,10 @@ class Backup:
         logger.info("Database backup %s restored", backup_file)
 
     def _backup_directory(self, directory: str):
+        if not os.path.exists(directory):
+            logger.info("Source directory %s does not exist, skipping", directory)
+            return
+
         overwrite_existing = self.config.files["overwrite_existing_directory"]
 
         dirname = os.path.basename(directory)
@@ -337,10 +344,6 @@ class Backup:
             else:
                 logger.info("Skipping %s", dest)
                 return
-
-        if not os.path.exists(directory):
-            logger.info("Source directory %s does not exist, skipping", directory)
-            return
 
         shutil.copytree(directory, dest)
 

--- a/ctrl_z/retention.py
+++ b/ctrl_z/retention.py
@@ -95,5 +95,6 @@ class RetentionPolicy:
             to_delete.append(os.path.join(base, dir_name))
 
         for path in to_delete:
-            logger.info("Pruning backup directory %s", path)
-            shutil.rmtree(path)
+            if os.path.isdir(path):
+                logger.info("Pruning backup directory %s", path)
+                shutil.rmtree(path, True)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -59,7 +59,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -183,5 +183,5 @@ def test_restore_folders_skip_folder(settings, tmpdir, config_writer, caplog):
     with caplog.at_level(logging.DEBUG):
         backup.restore(db=False)
 
-    assert bool(search("Not restoring.+NON_EXISTING_DIR - directory doesn't exist", caplog.text))
+    assert search("Not restoring.+NON_EXISTING_DIR - directory doesn't exist", caplog.text) is not None
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,18 @@
 [tox]
 envlist =
-  py{35,36,37,38,39}-django{111,20,21,22,32}
-  isort
+  py{37,38,39}-django{32}
+  isort{4.3.1}
   docs
 skip_missing_interpreters = true
 
 [travis:env]
 DJANGO =
-    1.11: django111
-    2.0: django20
-    2.1: django21
-    2.2: django22
     3.2: django32
 [testenv]
 extras =
     tests
     coverage
 deps =
-  django111: Django>=1.11,<2.0
-  django20: Django>=2.0,<2.1
-  django21: Django>=2.1,<2.2
-  django22: Django>=2.2,<3.0
   django32: Django>=3.2,<3.3
 passenv =
   PGUSER


### PR DESCRIPTION
- this version only supports 
  - django 3.2
  - python 3.7, 3.8 and 3.9
- prevent error in case prune of old backup fails
  no test case present since the list of directories that has to be deleted is determined in the rotation function and cannot be edited from the testcase without changing the structure. Used pdb to pause the code and manually delete a directory and continue the code afterwards to validate that the extra check is executed correctly. Also enabled the ignore_errors flag on shutil.rmtree to ensure ctrl-z doesn't crash in case of an unexpected error

to_delete contains 2 directories  
![image](https://user-images.githubusercontent.com/107030324/200319747-74671752-879a-4017-859b-db208c52ec4b.png)
deleted selected folder on the filesystem
![image](https://user-images.githubusercontent.com/107030324/200319886-c7389562-ced8-4c47-8684-833fabdc534d.png)
continue pdb
![image](https://user-images.githubusercontent.com/107030324/200319909-717d3e1c-d3a7-454d-bf4b-e93747d2ee93.png)

- prevent error in case no directory is specified in setting or when directory not exists