### PR TITLE
Make ctrl-z compatible with Python 3.11 to 3.14 and Django 4.2 + 5.2

### DIFF
--- a/ctrl_z/config.default.yml
+++ b/ctrl_z/config.default.yml
@@ -30,7 +30,7 @@ files:
     - MEDIA_ROOT
 
 # Which binaries to use for backup creation/restore
-pg_dump_binary: /opt/homebrew/Cellar/libpq/17.6/bin/pg_dump
-pg_restore_binary: /opt/homebrew/Cellar/libpq/17.6/bin/pg_restore
-dropdb_binary: /opt/homebrew/Cellar/libpq/17.6/bin/dropdb
-createdb_binary: /opt/homebrew/Cellar/libpq/17.6/bin/createdb
+pg_dump_binary: /opt/homebrew/Cellar/libpq/18.3/bin/pg_dump
+pg_restore_binary: /opt/homebrew/Cellar/libpq/18.3/bin/pg_restore
+dropdb_binary: /opt/homebrew/Cellar/libpq/18.3/bin/dropdb
+createdb_binary: /opt/homebrew/Cellar/libpq/18.3/bin/createdb

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -8,7 +8,7 @@ Installation
 Requirements
 ------------
 
-* Python 3.11, 3.12 of 3.13
+* Python 3.11, 3.12, 3.13 or 3.14
 * setuptools 63 or higher
 * PostgreSQL
 * Database user must have permissions to drop/create the target database(s)

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     python-dateutil
     pyyaml
 tests_require =
-    psycopg2-binary
+    psycopg[binary]
     pytest
     pytest-django
     freezegun
@@ -44,7 +44,7 @@ tests_require =
 
 [options.extras_require]
 tests =
-    psycopg2-binary
+    psycopg[binary]
     pytest
     pytest-django
     freezegun

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{311,312,313}-django{42,52}
+  py{311,312,313,314}-django{42,52}
   isort
   docs
 skip_missing_interpreters = true


### PR DESCRIPTION
Make ctrl-z compatible with Python 3.11 to 3.14 and Django 4.2 + 5.2
And updated psycopg2-binary to psycopg[binary] 

Local tests
<img width="1726" height="822" alt="image" src="https://github.com/user-attachments/assets/d8c45946-e616-466d-97d0-489185ccd69b" />
and
<img width="498" height="160" alt="image" src="https://github.com/user-attachments/assets/a3ca496e-7e5c-466a-8dd5-2257490b6061" />
